### PR TITLE
allow push

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -201,6 +201,9 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
         include /etc/nginx/caching.layer.listen;
         server_name _;
 
+        # allow to upload big layers
+        client_max_body_size 0;
+
         # Do some tweaked logging.
         access_log  /var/log/nginx/access.log  tweaked;
         set $docker_proxy_request_type "unknown";

--- a/nginx.conf
+++ b/nginx.conf
@@ -219,17 +219,6 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
         # Docker needs this. Don't ask.
         chunked_transfer_encoding on;
 
-        # Block POST/PUT/DELETE. Don't use this proxy for pushing.
-        if ($request_method = POST) {
-            return 405 "POST method is not allowed";
-        }
-        if ($request_method = PUT) {
-            return 405 "PUT method is not allowed";
-        }
-        if ($request_method = DELETE) {
-            return 405  "DELETE method is not allowed";
-        }
-
         proxy_read_timeout 900;
 
         # Use cache locking, with a huge timeout, so that multiple Docker clients asking for the same blob at the same time
@@ -239,6 +228,10 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
 
         # Cache all 200, 206 for 60 days.
         proxy_cache_valid 200 206 60d;
+
+        proxy_cache_convert_head off;
+        proxy_cache_methods GET;
+        proxy_cache_key $scheme$request_method$proxy_host$request_uri;
 
         # Some extra settings to maximize cache hits and efficiency
         proxy_force_ranges on;


### PR DESCRIPTION
1. create volumes 
```
$ docker volume create registry-ca
registry-ca
$ docker volume create registry-mirror-cache
registry-mirror-cache
```
2. run daemon
```
$ docker run --restart=always --name docker_registry_proxy -it -e DEBUG_NGINX=true -e DEBUG=true -e DEBUG_HUB=true -p 0.0.0.0:8081:8081 -p 0.0.0.0:8082:8082 -p 0.0.0.0:3128:3128 -e ENABLE_MANIFEST_CACHE=true --mount source=registry-mirror-cache,target=/docker_mirror_cache --mount source=registry-ca,target=/ca fgimenez/docker-registry-proxy:latest-debug
```
3. add environment vars pointing Docker to use the proxy
```
$ sudo mkdir -p /etc/systemd/system/docker.service.d
$ cat << EOD > http-proxy.conf
[Service]
Environment="HTTP_PROXY=http://localhost:3128/"
Environment="HTTPS_PROXY=http://localhost:3128/"
EOD
$ sudo mv http-proxy.conf /etc/systemd/system/docker.service.d/
```
4. get the CA certificate from the proxy and make it a trusted root.
```
$ curl http://localhost:3128/ca.crt > docker_registry_proxy.crt
$ sudo trust anchor ./docker_registry_proxy.crt
```
5. reload systemd and restart dockerd
```
$ systemctl daemon-reload
$ systemctl restart docker.service
```